### PR TITLE
wip on block structure

### DIFF
--- a/src/dpos/delegation.clj
+++ b/src/dpos/delegation.clj
@@ -58,3 +58,13 @@
 
 
 
+
+
+;; 200 genesis-stakeholders {:a 1 :b 9 :c 3....}
+;; 31 delegates
+;; initial vote  200 => 31
+
+
+; how to arrivate at the list of delegates? => "registration"
+
+;[{:parent nil, :height 0, :txs []} {:txs [0], :height 1, :parent #uuid "201986f3-84c2-5bd4-b296-508bf65995e5"} {:txs [1], :height 2, :parent #uuid "3e8e2bea-7694-5024-9b91-ebd4b4684a21"} {:txs [2], :height 3, :parent #uuid "13df1615-229a-5412-a6b2-7923451f653d"} {:txs [3], :height 4, :parent #uuid "16254acc-e951-5ea1-a6b6-c6b7393ad1fc"} {:txs [4], :height 5, :parent #uuid "016957ae-c937-5c9a-ba19-7fd6cda6ba3c"} {:txs [5], :height 6, :parent #uuid "238e5de3-6348-5114-a346-995f7f147554"} {:txs [6], :height 7, :parent #uuid "07668d7e-27f5-5725-b75e-701ad8b42e01"} {:txs [7], :height 8, :parent #uuid "2b3d6c69-b090-5d88-9b1e-b5b6c9157e36"} {:txs [8], :height 9, :parent #uuid "1ea6bee1-c0b9-56cd-8039-fe0502d90058"} {:txs [9], :height 10, :parent #uuid "31161db7-4d25-5eea-95a3-381e313aec83"}]


### PR DESCRIPTION
WIP on integration transactions and chains from the previous code base. the struct here should use hash. hash of a block is the hash of the transactions, not the meta-data (timestamp, height)

https://github.com/meta-project/dpos/blob/2785903c1fad70865a98f9b86f3c48f66473c06b/src/dpos/core.clj#L59

I am renaming a few vars, as they are common terms. pos => block-height

todo: rename pending to tx-pool (in Bitcoin mempool)